### PR TITLE
Add a few UI tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ dependencies = [
  "egui_extras",
  "env_logger",
  "scalarff",
+ "strip-ansi-escapes",
 ]
 
 [[package]]
@@ -3492,6 +3493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
+name = "strip-ansi-escapes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ff8ef943b384c414f54aefa961dd2bd853add74ec75e7ac74cf91dba62bcfa"
+dependencies = [
+ "vte",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3808,6 +3818,26 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vte"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5022b5fbf9407086c180e9557be968742d839e68346af7792b8592489732197"
+dependencies = [
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "waker-fn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ env_logger = { version = "0.11.5", default-features = false, features = ["auto-c
 ashlang = { git = "https://github.com/chancehudson/ashlang.git" }
 scalarff = "0.1.1"
 anyhow = "1.0.86"
+strip-ansi-escapes = "0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use scalarff::Bn128FieldElement;
 use scalarff::Curve25519FieldElement;
 use scalarff::FieldElement;
 use scalarff::FoiFieldElement;
+use strip_ansi_escapes;
 
 fn main() -> eframe::Result {
     env_logger::init(); // Log to stderr (if you run with `RUST_LOG=debug`).
@@ -72,8 +73,8 @@ impl IDE {
         let mut compiler: Compiler<T> = compiler.unwrap();
         let program = compiler.compile_str(&self.source);
         if let Err(e) = program {
-            self.compile_result = format!("Failed to compile ar1cs: {:?}", e);
-            self.compile_output = "".to_string();
+            self.compile_result = format!("Failed to compile to {}: {}", self.target, strip_ansi_escapes::strip_str(&e.to_string()));
+        self.compile_output = "".to_string();
             return;
         }
         let program = program.unwrap();
@@ -192,17 +193,23 @@ fn render_build_options(ide: &mut IDE, ui: &mut egui::Ui) {
 }
 
 fn render_build_info(ide: &mut IDE, ui: &mut egui::Ui) {
-    egui::ScrollArea::vertical()
-        .id_source("compile_output_scroll")
-        .show(ui, |ui| {
-            ui.vertical(|ui| {
-                ui.heading("Compile status");
-                ui.colored_label(egui::Color32::WHITE, &ide.compile_result);
+    ui.vertical(|ui| {
+        ui.heading("Compile status");
+        egui::ScrollArea::vertical()
+            .id_source("compile_status_scroll")
+            .auto_shrink([false, true])
+            .show(ui, |ui| {
+                ui.colored_label(egui::Color32::BLACK, &ide.compile_result);
             });
-            ui.add(egui::Separator::default());
-            ui.vertical(|ui| {
-                ui.heading("Compile output");
-                ui.colored_label(egui::Color32::WHITE, &ide.compile_output);
+    });
+    ui.add(egui::Separator::default());
+    ui.vertical(|ui| {
+        ui.heading("Compile output");
+        egui::ScrollArea::vertical()
+            .id_source("compile_output_scroll")
+            .auto_shrink([false, true])
+            .show(ui, |ui| {
+                ui.colored_label(egui::Color32::BLACK, &ide.compile_output);
             });
-        });
+    });
 }


### PR DESCRIPTION
## Changes

### 1. change text color of build info section more visible

<img width="772" alt="Screenshot 2024-09-05 at 14 38 46" src="https://github.com/user-attachments/assets/78ae0365-4cef-40ad-bb89-4a8cf88e57d0">

### 2. add separate scrollbars for each section of build info
![scroll](https://github.com/user-attachments/assets/f1db8664-0ba8-4b03-8624-87b6b2e05f03)


### 3. strip ANSI escape sequences