### PR TITLE
feat: display a pointing hand cursor when hovering over clickable UI elements

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -148,9 +148,11 @@ impl eframe::App for IDE {
                     ui.vertical(|ui| {
                         for (filename, _) in &self.fs {
                             let label = if self.active_file == filename.to_string() {
-                                ui.label(&format!("> {filename}"))
+                                let res = ui.label(&format!("> {filename}"));
+                                res.on_hover_cursor(egui::CursorIcon::PointingHand)
                             } else {
-                                ui.label(filename)
+                                let res = ui.label(filename);
+                                res.on_hover_cursor(egui::CursorIcon::PointingHand)
                             };
                             if label.clicked() {
                                 self.active_file = filename.clone();
@@ -177,7 +179,12 @@ impl eframe::App for IDE {
             });
         });
         egui::TopBottomPanel::bottom("bottom").show(ctx, |ui| {
-            egui::widgets::global_dark_light_mode_buttons(ui);
+            ui.horizontal(|ui| {
+                egui::widgets::global_dark_light_mode_buttons(ui);
+                if ui.ui_contains_pointer() {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                }
+            });
         });
     }
 }
@@ -199,6 +206,9 @@ fn render_build_options(ide: &mut IDE, ui: &mut egui::Ui) {
                 {
                     ide.compile_generic();
                 }
+                if ui.ui_contains_pointer() {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                }
             });
         egui::ComboBox::new("target_selector", "")
             .selected_text(format!("Target: {}", ide.target))
@@ -212,7 +222,13 @@ fn render_build_options(ide: &mut IDE, ui: &mut egui::Ui) {
                 {
                     ide.compile_generic();
                 }
+                if ui.ui_contains_pointer() {
+                    ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+                }
             });
+        if ui.ui_contains_pointer() {
+            ui.ctx().set_cursor_icon(egui::CursorIcon::PointingHand);
+        }
     });
 }
 


### PR DESCRIPTION
This PR uses [`egui::Context:set_cursor_icon`](https://docs.rs/egui/latest/egui/struct.Context.html#method.set_cursor_icon) or [`egui::Response::on_hover_cursor`](https://docs.rs/egui/latest/egui/struct.Response.html#method.on_hover_cursor) depending on the context, to appropriately change the cursor icon



![cursor](https://github.com/user-attachments/assets/e8050c26-184d-4bbd-b440-7ccdae8e04b7)


